### PR TITLE
Now can open `grades` tab.

### DIFF
--- a/src/Components/Panel/Grades/grades.jsx
+++ b/src/Components/Panel/Grades/grades.jsx
@@ -56,9 +56,11 @@ const Grades = () => {
     }
 
     const drawGradesWidgets = (grades) => {
+        if (!grades) return;
         let returnData = [];
 
         grades.sort((a, b) => {
+            if (!a || !b) return;
             const aDate = new Date(a.date.substring(0, 10));
             const bDate = new Date(b.date.substring(0, 10));
 

--- a/src/Components/TitleBar/titleBar.jsx
+++ b/src/Components/TitleBar/titleBar.jsx
@@ -9,7 +9,7 @@ import { globalDataContext } from '../../globalContext';
 import { useHistory } from 'react-router-dom';
 
 const ipcRenderer = window.require("electron").ipcRenderer;
-const appVersion = "1.0.0";
+const appVersion = "1.0.3"
 const isMac = process.platform === "darwin";
 
 const Titlebar = () => {


### PR DESCRIPTION
I found a bug that was preventing me from opening the grade card. This error was caused by my school running point-based assessments, which Librus-api does not support. Additionally, because of the point grades, Librus-api returns double the number of subjects because in librus the grades are separated into regular and point grades.

If I have some free time I will try to make my own API.